### PR TITLE
멘토링 세션 생성 및 등록 구현

### DIFF
--- a/src/main/java/com/gatheria/controller/AdminController.java
+++ b/src/main/java/com/gatheria/controller/AdminController.java
@@ -1,12 +1,20 @@
 package com.gatheria.controller;
 
+import com.gatheria.dto.request.AdminRegisterRequestDto;
+import com.gatheria.dto.request.MentoringSessionCreateRequestDto;
+import com.gatheria.dto.response.AdminRegisterResponseDto;
+import com.gatheria.dto.response.MentoringSessionCreateResponseDto;
 import com.gatheria.dto.response.PagedInstructorResponseDto;
+import com.gatheria.service.AdminService;
 import com.gatheria.service.MemberService;
+import com.gatheria.service.MentoringSessionService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,26 +22,58 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/admin")
 public class AdminController {
-    private final MemberService memberService;
 
-    @Autowired
-    public AdminController(MemberService memberService) {
-        this.memberService = memberService;
+  private final AdminService adminService;
+  private final MentoringSessionService mentoringSessionService;
+  private final MemberService memberService;
+
+  @Autowired
+  public AdminController(AdminService adminService, MentoringSessionService mentoringSessionService,
+      MemberService memberService) {
+    this.adminService = adminService;
+    this.mentoringSessionService = mentoringSessionService;
+    this.memberService = memberService;
+  }
+
+  @PostMapping("/register")
+  public ResponseEntity<AdminRegisterResponseDto> registerAdmin(
+      @RequestBody AdminRegisterRequestDto request) {
+    AdminRegisterResponseDto response = adminService.register(request);
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<String> login(@RequestParam String username,
+      @RequestParam String password) {
+    boolean success = adminService.login(username, password);
+    if (success) {
+      return ResponseEntity.ok("로그인 성공");
     }
-
-    @GetMapping("/pending-instructors")
-    public ResponseEntity<PagedInstructorResponseDto> showPendingInstructors(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size) {
-        PagedInstructorResponseDto response = memberService.showPendingInstructors(page, size);
-        return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/approve-instructor/{id}")
-    public ResponseEntity<Void> approveInstructor(@PathVariable Long id) {
-        memberService.approveInstructor(id);
-        return ResponseEntity.ok().build();
-    }
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 실패");
+  }
 
 
+  @GetMapping("/pending-instructors")
+  public ResponseEntity<PagedInstructorResponseDto> showPendingInstructors(
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "10") int size) {
+    PagedInstructorResponseDto response = memberService.showPendingInstructors(page, size);
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/approve-instructor/{id}")
+  public ResponseEntity<Void> approveInstructor(@PathVariable Long id) {
+    memberService.approveInstructor(id);
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/create-mentoring-session")
+  public ResponseEntity<MentoringSessionCreateResponseDto> createMentoringSession(
+      @RequestBody MentoringSessionCreateRequestDto request) {
+
+    MentoringSessionCreateResponseDto response = mentoringSessionService.createMentoringSession(
+        request);
+
+    return ResponseEntity.ok(response);
+  }
 }

--- a/src/main/java/com/gatheria/controller/MentoringSessionController.java
+++ b/src/main/java/com/gatheria/controller/MentoringSessionController.java
@@ -1,0 +1,47 @@
+package com.gatheria.controller;
+
+import com.gatheria.dto.request.MentoringSessionCreateRequestDto;
+import com.gatheria.dto.response.MentoringSessionCreateResponseDto;
+import com.gatheria.service.MentoringSessionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/mentoring")
+public class MentoringSessionController {
+
+  private final MentoringSessionService mentoringSessionService;
+
+  private static final String ADMIN_KEY = "admin123";
+
+  public MentoringSessionController(MentoringSessionService mentoringSessionService) {
+    this.mentoringSessionService = mentoringSessionService;
+  }
+
+  @PostMapping("/sessions")
+  public ResponseEntity<MentoringSessionCreateResponseDto> createMentoringSession(
+      @RequestBody MentoringSessionCreateRequestDto request,
+      @RequestParam String adminKey) {
+
+    boolean isAdmin = ADMIN_KEY.equals(adminKey);
+
+    if (!isAdmin) {
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+
+    MentoringSessionCreateResponseDto response = mentoringSessionService.createMentoringSession(
+        request);
+
+    return ResponseEntity.ok(response);
+  }
+
+//  public ResponseEntity<SessionRegistrationResponseDto> joinMentoringSession(
+//      @RequestBody SessionRegistrationRequestDto request,
+//      @Auth
+//  )
+}

--- a/src/main/java/com/gatheria/controller/MentoringSessionController.java
+++ b/src/main/java/com/gatheria/controller/MentoringSessionController.java
@@ -1,10 +1,14 @@
 package com.gatheria.controller;
 
+import com.gatheria.common.annotation.Auth;
+import com.gatheria.domain.type.AuthInfo;
 import com.gatheria.dto.request.MentoringSessionCreateRequestDto;
 import com.gatheria.dto.response.MentoringSessionCreateResponseDto;
+import com.gatheria.dto.response.SessionRegistrationResponseDto;
 import com.gatheria.service.MentoringSessionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +27,7 @@ public class MentoringSessionController {
     this.mentoringSessionService = mentoringSessionService;
   }
 
-  @PostMapping("/sessions")
+  @PostMapping("/create")
   public ResponseEntity<MentoringSessionCreateResponseDto> createMentoringSession(
       @RequestBody MentoringSessionCreateRequestDto request,
       @RequestParam String adminKey) {
@@ -40,8 +44,14 @@ public class MentoringSessionController {
     return ResponseEntity.ok(response);
   }
 
-//  public ResponseEntity<SessionRegistrationResponseDto> joinMentoringSession(
-//      @RequestBody SessionRegistrationRequestDto request,
-//      @Auth
-//  )
+  @PostMapping("/{sessionId}/join")
+  public ResponseEntity<SessionRegistrationResponseDto> joinMentoringSession(
+      @PathVariable Long sessionId,
+      @Auth AuthInfo authInfo) {
+
+    SessionRegistrationResponseDto response = mentoringSessionService.registerSession(
+        sessionId, authInfo);
+
+    return ResponseEntity.status(response.getStatus()).body(response);
+  }
 }

--- a/src/main/java/com/gatheria/controller/MentoringSessionController.java
+++ b/src/main/java/com/gatheria/controller/MentoringSessionController.java
@@ -2,17 +2,12 @@ package com.gatheria.controller;
 
 import com.gatheria.common.annotation.Auth;
 import com.gatheria.domain.type.AuthInfo;
-import com.gatheria.dto.request.MentoringSessionCreateRequestDto;
-import com.gatheria.dto.response.MentoringSessionCreateResponseDto;
 import com.gatheria.dto.response.SessionRegistrationResponseDto;
 import com.gatheria.service.MentoringSessionService;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,28 +16,10 @@ public class MentoringSessionController {
 
   private final MentoringSessionService mentoringSessionService;
 
-  private static final String ADMIN_KEY = "admin123";
-
   public MentoringSessionController(MentoringSessionService mentoringSessionService) {
     this.mentoringSessionService = mentoringSessionService;
   }
 
-  @PostMapping("/create")
-  public ResponseEntity<MentoringSessionCreateResponseDto> createMentoringSession(
-      @RequestBody MentoringSessionCreateRequestDto request,
-      @RequestParam String adminKey) {
-
-    boolean isAdmin = ADMIN_KEY.equals(adminKey);
-
-    if (!isAdmin) {
-      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-    }
-
-    MentoringSessionCreateResponseDto response = mentoringSessionService.createMentoringSession(
-        request);
-
-    return ResponseEntity.ok(response);
-  }
 
   @PostMapping("/{sessionId}/join")
   public ResponseEntity<SessionRegistrationResponseDto> joinMentoringSession(

--- a/src/main/java/com/gatheria/domain/Admin.java
+++ b/src/main/java/com/gatheria/domain/Admin.java
@@ -1,0 +1,19 @@
+package com.gatheria.domain;
+
+import com.gatheria.domain.type.AdminRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Admin {
+
+  private Long id;
+  private String username;
+  private String password;
+  private AdminRole role;
+}

--- a/src/main/java/com/gatheria/domain/MentoringSession.java
+++ b/src/main/java/com/gatheria/domain/MentoringSession.java
@@ -33,7 +33,14 @@ public class MentoringSession {
     return new MentoringSession(title, mentorName, sessionDate, maxParticipants);
   }
 
-  //TODO : 현재 참석자 수 증가
+  public void incrementCurrentParticipants() {
+    if (this.currentParticipants >= this.maxParticipants) {
+      throw new IllegalStateException("정원 초과");
+    }
+    this.currentParticipants++;
+    this.updatedAt = LocalDateTime.now();
+  }
+
   //TODO : 현재 참석자 수 감소
 
   //TODO : 멘토링 세션 취소

--- a/src/main/java/com/gatheria/domain/MentoringSession.java
+++ b/src/main/java/com/gatheria/domain/MentoringSession.java
@@ -1,6 +1,8 @@
 package com.gatheria.domain;
 
+import com.gatheria.domain.type.MentoringStatus;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.Getter;
 
 @Getter
@@ -10,27 +12,33 @@ public class MentoringSession {
   private final String title;
   private final String mentorName;
   private final LocalDateTime sessionDate;
+  private final LocalDateTime waitingStartDate;
+  private final LocalDateTime waitingEndDate;
   private final Integer maxParticipants;
   private Integer currentParticipants;
-  private String status;
+  private MentoringStatus status;
   private final LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
   private MentoringSession(String title, String mentorName, LocalDateTime sessionDate,
-      Integer maxParticipants) {
+      LocalDateTime waitingStartDate, LocalDateTime waitingEndDate, Integer maxParticipants) {
     this.title = title;
     this.mentorName = mentorName;
     this.sessionDate = sessionDate;
+    this.waitingStartDate = waitingStartDate;
+    this.waitingEndDate = waitingEndDate;
     this.maxParticipants = maxParticipants;
     this.currentParticipants = 0;
-    this.status = "OPEN";
+    this.status = MentoringStatus.SCHEDULED;
     this.createdAt = LocalDateTime.now();
     this.updatedAt = LocalDateTime.now();
   }
 
+
   public static MentoringSession of(String title, String mentorName, LocalDateTime sessionDate,
-      Integer maxParticipants) {
-    return new MentoringSession(title, mentorName, sessionDate, maxParticipants);
+      LocalDateTime waitingStartDate, LocalDateTime waitingEndDate, Integer maxParticipants) {
+    return new MentoringSession(title, mentorName, sessionDate, waitingStartDate, waitingEndDate,
+        maxParticipants);
   }
 
   public void incrementCurrentParticipants() {
@@ -39,11 +47,39 @@ public class MentoringSession {
     }
     this.currentParticipants++;
     this.updatedAt = LocalDateTime.now();
+
+    if (Objects.equals(this.currentParticipants, this.maxParticipants)) {
+      this.status = MentoringStatus.WAITING_CLOSED;
+    }
   }
 
-  //TODO : 현재 참석자 수 감소
+  public void decrementCurrentParticipants() {
+    if (this.currentParticipants > 0) {
+      this.currentParticipants--;
+      this.updatedAt = LocalDateTime.now();
+    }
 
-  //TODO : 멘토링 세션 취소
+    if (this.status == MentoringStatus.WAITING_CLOSED) {
+      this.status = MentoringStatus.WAITING_OPEN;
+    }
 
-  //TODO : 지금 가입할 수 있는가?
+    //TODO : 등록 대기 줄이 있는 상황 처리 (바로 wait open으로 변경하지 않고 대기줄이 있는 경우 처리)
+  }
+
+  public void cancel() {
+    if (this.status == MentoringStatus.COMPLETED) {
+      throw new IllegalStateException("이미 종료된 세션");
+    }
+    this.status = MentoringStatus.CANCELLED;
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  public boolean canJoin() {
+    return this.status == MentoringStatus.WAITING_OPEN
+        && this.currentParticipants < this.maxParticipants;
+  }
+
+  public void updateStateAuto() {
+    //TODO : 자동 상태 변경 로직이 여기서 있으면 언제 상태가 변하는건지 알기 어려운데 어디서 관리해야하는가
+  }
 }

--- a/src/main/java/com/gatheria/domain/MentoringSession.java
+++ b/src/main/java/com/gatheria/domain/MentoringSession.java
@@ -1,0 +1,42 @@
+package com.gatheria.domain;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class MentoringSession {
+
+  private Long id;
+  private final String title;
+  private final String mentorName;
+  private final LocalDateTime sessionDate;
+  private final Integer maxParticipants;
+  private Integer currentParticipants;
+  private String status;
+  private final LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  private MentoringSession(String title, String mentorName, LocalDateTime sessionDate,
+      Integer maxParticipants) {
+    this.title = title;
+    this.mentorName = mentorName;
+    this.sessionDate = sessionDate;
+    this.maxParticipants = maxParticipants;
+    this.currentParticipants = 0;
+    this.status = "OPEN";
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  public static MentoringSession of(String title, String mentorName, LocalDateTime sessionDate,
+      Integer maxParticipants) {
+    return new MentoringSession(title, mentorName, sessionDate, maxParticipants);
+  }
+
+  //TODO : 현재 참석자 수 증가
+  //TODO : 현재 참석자 수 감소
+
+  //TODO : 멘토링 세션 취소
+
+  //TODO : 지금 가입할 수 있는가?
+}

--- a/src/main/java/com/gatheria/domain/SessionParticipant.java
+++ b/src/main/java/com/gatheria/domain/SessionParticipant.java
@@ -1,0 +1,40 @@
+package com.gatheria.domain;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class SessionParticipant {
+
+  private Long id;
+  private final Long sessionId;
+  private final Long studentId;
+  private LocalDateTime registrationTime; // final 제거
+  private String status;
+  private LocalDateTime cancelledAt;
+
+  private SessionParticipant(Long sessionId, Long studentId) {
+    this.sessionId = sessionId;
+    this.studentId = studentId;
+    this.registrationTime = LocalDateTime.now();
+    this.status = "REGISTERED";
+    this.cancelledAt = null;
+  }
+
+  public static SessionParticipant of(Long sessionId, Long studentId) {
+    return new SessionParticipant(sessionId, studentId);
+  }
+
+  public void cancel() {
+    this.status = "CANCELLED";
+    this.cancelledAt = LocalDateTime.now();
+  }
+
+  public static SessionParticipant reRegister(SessionParticipant existing) {
+    existing.status = "REGISTERED";
+    existing.registrationTime = LocalDateTime.now();
+    existing.cancelledAt = null;
+    return existing;
+  }
+
+}

--- a/src/main/java/com/gatheria/domain/SessionParticipant.java
+++ b/src/main/java/com/gatheria/domain/SessionParticipant.java
@@ -1,5 +1,6 @@
 package com.gatheria.domain;
 
+import com.gatheria.domain.type.SessionParticipantStatus;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
@@ -9,15 +10,15 @@ public class SessionParticipant {
   private Long id;
   private final Long sessionId;
   private final Long studentId;
-  private LocalDateTime registrationTime; // final 제거
-  private String status;
+  private LocalDateTime registrationTime;
+  private SessionParticipantStatus status;
   private LocalDateTime cancelledAt;
 
   private SessionParticipant(Long sessionId, Long studentId) {
     this.sessionId = sessionId;
     this.studentId = studentId;
     this.registrationTime = LocalDateTime.now();
-    this.status = "REGISTERED";
+    this.status = SessionParticipantStatus.REGISTERED;
     this.cancelledAt = null;
   }
 
@@ -26,15 +27,14 @@ public class SessionParticipant {
   }
 
   public void cancel() {
-    this.status = "CANCELLED";
+    this.status = SessionParticipantStatus.CANCELLED;
     this.cancelledAt = LocalDateTime.now();
   }
 
-  public static SessionParticipant reRegister(SessionParticipant existing) {
-    existing.status = "REGISTERED";
+  public static void reRegister(SessionParticipant existing) {
+    existing.status = SessionParticipantStatus.REGISTERED;
     existing.registrationTime = LocalDateTime.now();
     existing.cancelledAt = null;
-    return existing;
   }
 
 }

--- a/src/main/java/com/gatheria/domain/type/AdminRole.java
+++ b/src/main/java/com/gatheria/domain/type/AdminRole.java
@@ -1,0 +1,8 @@
+package com.gatheria.domain.type;
+
+import lombok.Getter;
+
+@Getter
+public enum AdminRole {
+  SUPER_ADMIN, ADMIN;
+}

--- a/src/main/java/com/gatheria/domain/type/AuthInfo.java
+++ b/src/main/java/com/gatheria/domain/type/AuthInfo.java
@@ -18,4 +18,8 @@ public class AuthInfo {
   public boolean isInstructor() {
     return this.role == MemberRole.INSTRUCTOR;
   }
+
+  public boolean isStudent() {
+    return this.role == MemberRole.STUDENT;
+  }
 }

--- a/src/main/java/com/gatheria/domain/type/MentoringStatus.java
+++ b/src/main/java/com/gatheria/domain/type/MentoringStatus.java
@@ -1,0 +1,12 @@
+package com.gatheria.domain.type;
+
+import lombok.Getter;
+
+@Getter
+public enum MentoringStatus {
+  SCHEDULED,
+  WAITING_OPEN,
+  WAITING_CLOSED,
+  COMPLETED,
+  CANCELLED
+}

--- a/src/main/java/com/gatheria/domain/type/SessionParticipantStatus.java
+++ b/src/main/java/com/gatheria/domain/type/SessionParticipantStatus.java
@@ -1,0 +1,9 @@
+package com.gatheria.domain.type;
+
+import lombok.Getter;
+
+@Getter
+public enum SessionParticipantStatus {
+  REGISTERED,
+  CANCELLED
+}

--- a/src/main/java/com/gatheria/dto/request/AdminRegisterRequestDto.java
+++ b/src/main/java/com/gatheria/dto/request/AdminRegisterRequestDto.java
@@ -1,0 +1,21 @@
+package com.gatheria.dto.request;
+
+import com.gatheria.domain.Admin;
+import com.gatheria.domain.type.AdminRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminRegisterRequestDto {
+
+  private String username;
+  private String password;
+  private String role;
+
+  public Admin toDomain(String encodedPassword) {
+    return new Admin(null, this.username, encodedPassword, AdminRole.valueOf(this.role));
+  }
+}

--- a/src/main/java/com/gatheria/dto/request/MentoringSessionCreateRequestDto.java
+++ b/src/main/java/com/gatheria/dto/request/MentoringSessionCreateRequestDto.java
@@ -13,5 +13,7 @@ public class MentoringSessionCreateRequestDto {
   private String title;
   private String mentorName;
   private LocalDateTime sessionDate;
+  private LocalDateTime waitingStartDate;
+  private LocalDateTime waitingEndDate;
   private Integer maxParticipants;
 }

--- a/src/main/java/com/gatheria/dto/request/MentoringSessionCreateRequestDto.java
+++ b/src/main/java/com/gatheria/dto/request/MentoringSessionCreateRequestDto.java
@@ -1,0 +1,17 @@
+package com.gatheria.dto.request;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MentoringSessionCreateRequestDto {
+
+  private String title;
+  private String mentorName;
+  private LocalDateTime sessionDate;
+  private Integer maxParticipants;
+}

--- a/src/main/java/com/gatheria/dto/response/AdminRegisterResponseDto.java
+++ b/src/main/java/com/gatheria/dto/response/AdminRegisterResponseDto.java
@@ -1,0 +1,18 @@
+package com.gatheria.dto.response;
+
+import com.gatheria.domain.Admin;
+import com.gatheria.domain.type.AdminRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminRegisterResponseDto {
+
+  private String username;
+  private AdminRole role;
+
+  public static AdminRegisterResponseDto from(Admin admin) {
+    return new AdminRegisterResponseDto(admin.getUsername(), admin.getRole());
+  }
+}

--- a/src/main/java/com/gatheria/dto/response/MentoringSessionCreateResponseDto.java
+++ b/src/main/java/com/gatheria/dto/response/MentoringSessionCreateResponseDto.java
@@ -1,0 +1,31 @@
+package com.gatheria.dto.response;
+
+import com.gatheria.domain.MentoringSession;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MentoringSessionCreateResponseDto {
+
+  private Long id;
+  private String title;
+  private String mentorName;
+  private LocalDateTime sessionDate;
+  private Integer maxParticipants;
+
+  public static MentoringSessionCreateResponseDto of(MentoringSession session) {
+    return new MentoringSessionCreateResponseDto(
+        session.getId(),
+        session.getTitle(),
+        session.getMentorName(),
+        session.getSessionDate(),
+        session.getMaxParticipants()
+    );
+  }
+}

--- a/src/main/java/com/gatheria/dto/response/SessionRegistrationResponseDto.java
+++ b/src/main/java/com/gatheria/dto/response/SessionRegistrationResponseDto.java
@@ -30,7 +30,7 @@ public class SessionRegistrationResponseDto {
         sessionId,
         sessionTitle,
         sessionDate,
-        "멘토링 세션 등록 완료.",
+        null,
         HttpStatus.OK
     );
   }

--- a/src/main/java/com/gatheria/dto/response/SessionRegistrationResponseDto.java
+++ b/src/main/java/com/gatheria/dto/response/SessionRegistrationResponseDto.java
@@ -1,0 +1,41 @@
+package com.gatheria.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SessionRegistrationResponseDto {
+
+  private boolean success;
+  private Long sessionId;
+  private String sessionTitle;
+  private LocalDateTime sessionDate;
+  private String message;
+  private HttpStatus status;
+
+  public static SessionRegistrationResponseDto success(
+      Long sessionId,
+      String sessionTitle,
+      LocalDateTime sessionDate) {
+
+    return new SessionRegistrationResponseDto(
+        true,
+        sessionId,
+        sessionTitle,
+        sessionDate,
+        "멘토링 세션 등록 완료.",
+        HttpStatus.OK
+    );
+  }
+
+  public static SessionRegistrationResponseDto fail(String message, HttpStatus status) {
+    return new SessionRegistrationResponseDto(false, null, null, null, message, status);
+  }
+}

--- a/src/main/java/com/gatheria/mapper/AdminMapper.java
+++ b/src/main/java/com/gatheria/mapper/AdminMapper.java
@@ -1,0 +1,22 @@
+package com.gatheria.mapper;
+
+import com.gatheria.domain.Admin;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface AdminMapper {
+
+  @Select("SELECT * FROM admins WHERE username = #{username}")
+  Admin findByUsername(@Param("username") String username);
+
+  @Select("SELECT COUNT(*) > 0 FROM admins WHERE username = #{username}")
+  boolean existsByUsername(@Param("username") String username);
+
+  @Insert("INSERT INTO admins (username, password, role) VALUES (#{username}, #{password}, #{role})")
+  @Options(useGeneratedKeys = true, keyProperty = "id")
+  void insertAdmin(Admin admin);
+}

--- a/src/main/java/com/gatheria/mapper/MentoringSessionMapper.java
+++ b/src/main/java/com/gatheria/mapper/MentoringSessionMapper.java
@@ -1,9 +1,12 @@
 package com.gatheria.mapper;
 
 import com.gatheria.domain.MentoringSession;
+import com.gatheria.domain.SessionParticipant;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 @Mapper
 public interface MentoringSessionMapper {
@@ -15,4 +18,24 @@ public interface MentoringSessionMapper {
       "#{currentParticipants}, #{status}, #{createdAt}, #{updatedAt})")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void insertSession(MentoringSession session);
+
+  @Select("SELECT * FROM mentoring_sessions WHERE id = #{sessionId} FOR UPDATE")
+  MentoringSession getSessionWithLock(Long sessionId);
+
+  @Select("SELECT * FROM session_participants WHERE session_id = #{sessionId} AND student_id = #{studentId}")
+  SessionParticipant findBySessionAndStudent(Long sessionId, Long memberId);
+
+  @Update("UPDATE mentoring_sessions SET " +
+      "current_participants = #{currentParticipants}, " +
+      "status = #{status}, " +
+      "updated_at = NOW() " +
+      "WHERE id = #{id}")
+  void updateSession(MentoringSession session);
+
+  @Insert("INSERT INTO session_participants " +
+      "(session_id, student_id, status, registration_time, cancelled_at) " +
+      "VALUES " +
+      "(#{sessionId}, #{studentId}, #{status}, #{registrationTime}, #{cancelledAt})")
+  @Options(useGeneratedKeys = true, keyProperty = "id")
+  void insertParticipant(SessionParticipant participant);
 }

--- a/src/main/java/com/gatheria/mapper/MentoringSessionMapper.java
+++ b/src/main/java/com/gatheria/mapper/MentoringSessionMapper.java
@@ -12,9 +12,10 @@ import org.apache.ibatis.annotations.Update;
 public interface MentoringSessionMapper {
 
   @Insert("INSERT INTO mentoring_sessions (" +
-      "title, mentor_name, session_date, max_participants, " +
+      "title, mentor_name, session_date, waiting_start_date, waiting_end_date, max_participants, " +
       "current_participants, status, created_at, updated_at) " +
-      "VALUES (#{title}, #{mentorName}, #{sessionDate}, #{maxParticipants}, " +
+      "VALUES (#{title}, #{mentorName}, #{sessionDate}, #{waitingStartDate}, #{waitingEndDate}, #{maxParticipants}, "
+      +
       "#{currentParticipants}, #{status}, #{createdAt}, #{updatedAt})")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void insertSession(MentoringSession session);

--- a/src/main/java/com/gatheria/mapper/MentoringSessionMapper.java
+++ b/src/main/java/com/gatheria/mapper/MentoringSessionMapper.java
@@ -19,9 +19,6 @@ public interface MentoringSessionMapper {
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void insertSession(MentoringSession session);
 
-  @Select("SELECT * FROM mentoring_sessions WHERE id = #{sessionId} FOR UPDATE")
-  MentoringSession getSessionWithLock(Long sessionId);
-
   @Select("SELECT * FROM session_participants WHERE session_id = #{sessionId} AND student_id = #{studentId}")
   SessionParticipant findBySessionAndStudent(Long sessionId, Long memberId);
 
@@ -38,4 +35,14 @@ public interface MentoringSessionMapper {
       "(#{sessionId}, #{studentId}, #{status}, #{registrationTime}, #{cancelledAt})")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void insertParticipant(SessionParticipant participant);
+
+  @Update("UPDATE session_participants SET " +
+      "status = #{status}, " +
+      "registration_time = #{registrationTime}, " +
+      "cancelled_at = #{cancelledAt} " +
+      "WHERE session_id = #{sessionId} AND student_id = #{studentId}")
+  void updateParticipant(SessionParticipant participant);
+
+  @Select("SELECT * FROM mentoring_sessions WHERE id = #{sessionId}")
+  MentoringSession getSession(Long sessionId);
 }

--- a/src/main/java/com/gatheria/mapper/MentoringSessionMapper.java
+++ b/src/main/java/com/gatheria/mapper/MentoringSessionMapper.java
@@ -1,0 +1,18 @@
+package com.gatheria.mapper;
+
+import com.gatheria.domain.MentoringSession;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+
+@Mapper
+public interface MentoringSessionMapper {
+
+  @Insert("INSERT INTO mentoring_sessions (" +
+      "title, mentor_name, session_date, max_participants, " +
+      "current_participants, status, created_at, updated_at) " +
+      "VALUES (#{title}, #{mentorName}, #{sessionDate}, #{maxParticipants}, " +
+      "#{currentParticipants}, #{status}, #{createdAt}, #{updatedAt})")
+  @Options(useGeneratedKeys = true, keyProperty = "id")
+  void insertSession(MentoringSession session);
+}

--- a/src/main/java/com/gatheria/service/AdminService.java
+++ b/src/main/java/com/gatheria/service/AdminService.java
@@ -1,0 +1,39 @@
+package com.gatheria.service;
+
+import com.gatheria.common.config.PasswordConfig.PasswordEncoder;
+import com.gatheria.domain.Admin;
+import com.gatheria.domain.type.AdminRole;
+import com.gatheria.dto.request.AdminRegisterRequestDto;
+import com.gatheria.dto.response.AdminRegisterResponseDto;
+import com.gatheria.mapper.AdminMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AdminService {
+
+  private final AdminMapper adminMapper;
+  private final PasswordEncoder passwordEncoder;
+
+  public AdminService(AdminMapper adminMapper, PasswordEncoder passwordEncoder) {
+    this.adminMapper = adminMapper;
+    this.passwordEncoder = passwordEncoder;
+  }
+
+  public AdminRegisterResponseDto register(AdminRegisterRequestDto request) {
+    if (adminMapper.existsByUsername(request.getUsername())) {
+      throw new RuntimeException("이미 존재하는 관리자 계정입니다.");
+    }
+
+    String encodedPassword = passwordEncoder.encode(request.getPassword());
+    Admin newAdmin = new Admin(null, request.getUsername(), encodedPassword, AdminRole.SUPER_ADMIN);
+
+    adminMapper.insertAdmin(newAdmin);
+
+    return AdminRegisterResponseDto.from(newAdmin);
+  }
+
+  public boolean login(String username, String password) {
+    Admin admin = adminMapper.findByUsername(username);
+    return admin != null && passwordEncoder.matches(password, admin.getPassword());
+  }
+}

--- a/src/main/java/com/gatheria/service/MentoringSessionService.java
+++ b/src/main/java/com/gatheria/service/MentoringSessionService.java
@@ -1,0 +1,32 @@
+package com.gatheria.service;
+
+import com.gatheria.domain.MentoringSession;
+import com.gatheria.dto.request.MentoringSessionCreateRequestDto;
+import com.gatheria.dto.response.MentoringSessionCreateResponseDto;
+import com.gatheria.mapper.MentoringSessionMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MentoringSessionService {
+
+  private final MentoringSessionMapper mentoringSessionMapper;
+
+  public MentoringSessionService(MentoringSessionMapper mentoringSessionMapper) {
+    this.mentoringSessionMapper = mentoringSessionMapper;
+  }
+
+  public MentoringSessionCreateResponseDto createMentoringSession(
+      MentoringSessionCreateRequestDto request) {
+
+    MentoringSession session = MentoringSession.of(
+        request.getTitle(),
+        request.getMentorName(),
+        request.getSessionDate(),
+        request.getMaxParticipants()
+    );
+
+    mentoringSessionMapper.insertSession(session);
+
+    return MentoringSessionCreateResponseDto.of(session);
+  }
+}

--- a/src/main/java/com/gatheria/service/MentoringSessionService.java
+++ b/src/main/java/com/gatheria/service/MentoringSessionService.java
@@ -3,6 +3,8 @@ package com.gatheria.service;
 import com.gatheria.domain.MentoringSession;
 import com.gatheria.domain.SessionParticipant;
 import com.gatheria.domain.type.AuthInfo;
+import com.gatheria.domain.type.MentoringStatus;
+import com.gatheria.domain.type.SessionParticipantStatus;
 import com.gatheria.dto.request.MentoringSessionCreateRequestDto;
 import com.gatheria.dto.response.MentoringSessionCreateResponseDto;
 import com.gatheria.dto.response.SessionRegistrationResponseDto;
@@ -29,6 +31,8 @@ public class MentoringSessionService {
         request.getTitle(),
         request.getMentorName(),
         request.getSessionDate(),
+        request.getWaitingStartDate(),
+        request.getWaitingEndDate(),
         request.getMaxParticipants()
     );
 
@@ -39,7 +43,7 @@ public class MentoringSessionService {
 
   @Transactional
   public SessionRegistrationResponseDto registerSession(Long sessionId, AuthInfo authInfo) {
-
+    // TODO : AuthInfo 수정 PR 반영 이후 수정 필요
     if (!authInfo.isStudent()) {
       throw new RuntimeException("학생만 가능함");
     }
@@ -53,11 +57,11 @@ public class MentoringSessionService {
     SessionParticipant existing = mentoringSessionMapper.findBySessionAndStudent(sessionId,
         authInfo.getMemberId());
 
-    if (existing != null && "REGISTERED".equals(existing.getStatus())) {
+    if (existing != null && SessionParticipantStatus.REGISTERED == existing.getStatus()) {
       return SessionRegistrationResponseDto.fail("이미 등록된 세션입니다.", HttpStatus.CONFLICT);
     }
 
-    if (!"OPEN".equals(session.getStatus())) {
+    if (session.getStatus() != MentoringStatus.WAITING_OPEN) {
       return SessionRegistrationResponseDto.fail(
           "현재 등록 불가 , 세션 상태: " + session.getStatus(),
           HttpStatus.BAD_REQUEST

--- a/src/main/java/com/gatheria/service/MentoringSessionService.java
+++ b/src/main/java/com/gatheria/service/MentoringSessionService.java
@@ -1,16 +1,23 @@
 package com.gatheria.service;
 
 import com.gatheria.domain.MentoringSession;
+import com.gatheria.domain.SessionParticipant;
+import com.gatheria.domain.type.AuthInfo;
 import com.gatheria.dto.request.MentoringSessionCreateRequestDto;
 import com.gatheria.dto.response.MentoringSessionCreateResponseDto;
+import com.gatheria.dto.response.SessionRegistrationResponseDto;
 import com.gatheria.mapper.MentoringSessionMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MentoringSessionService {
 
   private final MentoringSessionMapper mentoringSessionMapper;
 
+  @Autowired
   public MentoringSessionService(MentoringSessionMapper mentoringSessionMapper) {
     this.mentoringSessionMapper = mentoringSessionMapper;
   }
@@ -28,5 +35,53 @@ public class MentoringSessionService {
     mentoringSessionMapper.insertSession(session);
 
     return MentoringSessionCreateResponseDto.of(session);
+  }
+
+  @Transactional
+  public SessionRegistrationResponseDto registerSession(Long sessionId, AuthInfo authInfo) {
+
+    if (!authInfo.isStudent()) {
+      throw new RuntimeException("학생만 가능함");
+    }
+
+    MentoringSession session = mentoringSessionMapper.getSessionWithLock(sessionId);
+
+    if (session == null) {
+      return SessionRegistrationResponseDto.fail("해당 세션이 존재x.", HttpStatus.NOT_FOUND);
+    }
+
+    SessionParticipant existing = mentoringSessionMapper.findBySessionAndStudent(sessionId,
+        authInfo.getMemberId());
+
+    if (existing != null && "REGISTERED".equals(existing.getStatus())) {
+      return SessionRegistrationResponseDto.fail("이미 등록된 세션입니다.", HttpStatus.CONFLICT);
+    }
+
+    if (!"OPEN".equals(session.getStatus())) {
+      return SessionRegistrationResponseDto.fail(
+          "현재 등록 불가 , 세션 상태: " + session.getStatus(),
+          HttpStatus.BAD_REQUEST
+      );
+    }
+
+    if (session.getCurrentParticipants() >= session.getMaxParticipants()) {
+      return SessionRegistrationResponseDto.fail("정원 초과", HttpStatus.CONFLICT);
+    }
+
+    session.incrementCurrentParticipants();
+    mentoringSessionMapper.updateSession(session);
+
+    if (existing != null) {
+      SessionParticipant.reRegister(existing);
+    } else {
+      SessionParticipant participant = SessionParticipant.of(sessionId, authInfo.getMemberId());
+      mentoringSessionMapper.insertParticipant(participant);
+    }
+
+    return SessionRegistrationResponseDto.success(
+        session.getId(),
+        session.getTitle(),
+        session.getSessionDate()
+    );
   }
 }

--- a/src/main/java/com/gatheria/service/MentoringSessionService.java
+++ b/src/main/java/com/gatheria/service/MentoringSessionService.java
@@ -44,7 +44,7 @@ public class MentoringSessionService {
       throw new RuntimeException("학생만 가능함");
     }
 
-    MentoringSession session = mentoringSessionMapper.getSessionWithLock(sessionId);
+    MentoringSession session = mentoringSessionMapper.getSession(sessionId);
 
     if (session == null) {
       return SessionRegistrationResponseDto.fail("해당 세션이 존재x.", HttpStatus.NOT_FOUND);
@@ -73,6 +73,7 @@ public class MentoringSessionService {
 
     if (existing != null) {
       SessionParticipant.reRegister(existing);
+      mentoringSessionMapper.updateParticipant(existing);
     } else {
       SessionParticipant participant = SessionParticipant.of(sessionId, authInfo.getMemberId());
       mentoringSessionMapper.insertParticipant(participant);


### PR DESCRIPTION
### 구현 내용

디비 테이블 추가
- 멘토링 세션 테이블(mentoring_sessions)
- 세션 참가자 테이블(session_participants) 

기능 구현
- 관리자 권한을 가진 사용자의 멘토링 세션 생성 기능
- 학생의 멘토링 세션 참가 신청 기능 (선착순)
- 비관적 락(SELECT FOR UPDATE)을 사용

미구현 사항
- [x] 멘토링 등록 취소 기능
- [ ] 취소 시 대기 인원 등록
- [ ] 기능 테스트 진행 x (시간이 없어 일단 올려봅니다)

### 메인 리뷰어 지정 및 Due Date
@blue000927

### 관련 이슈
#23 
#24 

체크리스트

- [x]  PR 제목을 명령형으로 작성했습니다.
- [x]  PR을 연관되는 github issue에 연결했습니다.
- [ ]  리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다.

