### PR TITLE
AuthInfo 클래스의 역할별 ID 관리 구조 개선

### DIFF
--- a/src/main/java/com/gatheria/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gatheria/common/jwt/JwtAuthenticationFilter.java
@@ -66,7 +66,16 @@ public class JwtAuthenticationFilter implements Filter {
         MemberRole role = MemberRole.fromString(jwtUtil.extractRole(token));
         Long memberId = jwtUtil.extractMemberId(token);
 
-        AuthInfo authInfo = new AuthInfo(email, role, memberId);
+        Long studentId = null;
+        Long instructorId = null;
+
+        if (role == MemberRole.STUDENT) {
+          studentId = jwtUtil.extractStudentId(token);
+        } else if (role == MemberRole.INSTRUCTOR) {
+          instructorId = jwtUtil.extractInstructorId(token);
+        }
+
+        AuthInfo authInfo = new AuthInfo(email, role, memberId, studentId, instructorId);
 
         httpRequest.setAttribute("authInfo", authInfo);
 

--- a/src/main/java/com/gatheria/common/jwt/JwtUtil.java
+++ b/src/main/java/com/gatheria/common/jwt/JwtUtil.java
@@ -49,7 +49,7 @@ public class JwtUtil {
         .setSubject(email)
         .claim("role", role)
         .claim("memberId", memberId)
-        .claim("instructorId", instructorId)  // 교수자 ID 추가
+        .claim("instructorId", instructorId)
         .setIssuedAt(now)
         .setExpiration(expiration)
         .signWith(getSigningKey(), SignatureAlgorithm.HS256)

--- a/src/main/java/com/gatheria/common/jwt/JwtUtil.java
+++ b/src/main/java/com/gatheria/common/jwt/JwtUtil.java
@@ -24,8 +24,8 @@ public class JwtUtil {
     return Keys.hmacShaKeyFor(secretKey.getBytes());
   }
 
-  public String createAccessToken(String email, String role, Long memberId) {
 
+  public String createStudentAccessToken(String email, String role, Long memberId, Long studentId) {
     Date now = new Date();
     Date expiration = new Date(now.getTime() + expirationTime);
 
@@ -33,6 +33,23 @@ public class JwtUtil {
         .setSubject(email)
         .claim("role", role)
         .claim("memberId", memberId)
+        .claim("studentId", studentId)
+        .setIssuedAt(now)
+        .setExpiration(expiration)
+        .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  public String createInstructorAccessToken(String email, String role, Long memberId,
+      Long instructorId) {
+    Date now = new Date();
+    Date expiration = new Date(now.getTime() + expirationTime);
+
+    return Jwts.builder()
+        .setSubject(email)
+        .claim("role", role)
+        .claim("memberId", memberId)
+        .claim("instructorId", instructorId)  // 교수자 ID 추가
         .setIssuedAt(now)
         .setExpiration(expiration)
         .signWith(getSigningKey(), SignatureAlgorithm.HS256)
@@ -77,4 +94,12 @@ public class JwtUtil {
     return extractClaims(token).get("memberId", Long.class);
   }
 
+
+  public Long extractStudentId(String token) {
+    return extractClaims(token).get("studentId", Long.class);
+  }
+
+  public Long extractInstructorId(String token) {
+    return extractClaims(token).get("instructorId", Long.class);
+  }
 }

--- a/src/main/java/com/gatheria/controller/InstructorLectureController.java
+++ b/src/main/java/com/gatheria/controller/InstructorLectureController.java
@@ -36,7 +36,7 @@ public class InstructorLectureController {
   @GetMapping
   public ResponseEntity<List<LectureResponseDto>> showLectureList(
       @Auth AuthInfo authInfo) {
-    List<LectureResponseDto> lectures = lectureService.getLectureListByInstructorID(authInfo);
+    List<LectureResponseDto> lectures = lectureService.getLectureListByInstructorId(authInfo);
     return ResponseEntity.ok(lectures);
   }
 

--- a/src/main/java/com/gatheria/domain/type/AuthInfo.java
+++ b/src/main/java/com/gatheria/domain/type/AuthInfo.java
@@ -8,14 +8,23 @@ public class AuthInfo {
   private final String email;
   private final MemberRole role;
   private final Long memberId;
+  private final Long studentId;
+  private final Long instructorId;
 
-  public AuthInfo(String email, MemberRole role, Long memberId) {
+  public AuthInfo(String email, MemberRole role, Long memberId, Long studentId, Long instructorId) {
     this.email = email;
     this.role = role;
     this.memberId = memberId;
+    this.studentId = studentId;
+    this.instructorId = instructorId;
   }
+
 
   public boolean isInstructor() {
     return this.role == MemberRole.INSTRUCTOR;
+  }
+
+  public boolean isStudent() {
+    return this.role == MemberRole.STUDENT;
   }
 }

--- a/src/main/java/com/gatheria/mapper/AuthMapper.java
+++ b/src/main/java/com/gatheria/mapper/AuthMapper.java
@@ -3,9 +3,16 @@ package com.gatheria.mapper;
 import com.gatheria.domain.Instructor;
 import com.gatheria.domain.Student;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface AuthMapper {
-    Student findStudentByEmail(String email);
-    Instructor findInstructorByEmail(String email);
+
+  Student findStudentByEmail(String email);
+
+  Instructor findInstructorByEmail(String email);
+
+  Long findStudentIdByMemberId(@Param("memberId") Long memberId);
+
+  Long findInstructorIdByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/gatheria/mapper/LectureMapper.java
+++ b/src/main/java/com/gatheria/mapper/LectureMapper.java
@@ -12,7 +12,7 @@ public interface LectureMapper {
 
   void insertLecture(Lecture lecture);
 
-  List<Lecture> findByInstructorId(Long memberId);
+  List<Lecture> findByInstructorId(Long instructorId);
 
   @Select("SELECT lecture_id FROM lecture_students WHERE student_id = #{studentId}")
   List<Long> findLectureIdsByStudentId(@Param("studentId") Long studentId);

--- a/src/main/java/com/gatheria/mapper/MemberMapper.java
+++ b/src/main/java/com/gatheria/mapper/MemberMapper.java
@@ -26,6 +26,6 @@ public interface MemberMapper {
 
   void insertStudent(Student student);
 
-  @Select("SELECT * FROM students WHERE id = #{memberId}")
-  Student findStudentById(Long memberId);
+  @Select("SELECT * FROM students WHERE id = #{studentId}")
+  Student findStudentById(Long studentId);
 }

--- a/src/main/java/com/gatheria/service/AuthService.java
+++ b/src/main/java/com/gatheria/service/AuthService.java
@@ -41,8 +41,29 @@ public class AuthService {
       throw new RuntimeException("Invalid Password");
     }
 
-    String accessToken = jwtUtil.createAccessToken(request.getEmail(), role.getValue(),
-        member.getId());
+    String accessToken = null;
+
+    switch (role) {
+      case STUDENT:
+        Long studentId = authMapper.findStudentIdByMemberId(member.getId());
+        accessToken = jwtUtil.createStudentAccessToken(
+            request.getEmail(),
+            role.getValue(),
+            member.getId(),
+            studentId
+        );
+        break;
+
+      case INSTRUCTOR:
+        Long instructorId = authMapper.findInstructorIdByMemberId(member.getId());
+        accessToken = jwtUtil.createInstructorAccessToken(
+            request.getEmail(),
+            role.getValue(),
+            member.getId(),
+            instructorId
+        );
+        break;
+    }
 
     return LoginResponseDto.from(accessToken, member);
   }

--- a/src/main/java/com/gatheria/service/LectureService.java
+++ b/src/main/java/com/gatheria/service/LectureService.java
@@ -30,17 +30,36 @@ public class LectureService {
     if (authInfo.getRole() != MemberRole.INSTRUCTOR) {
       throw new RuntimeException();
     }
-    Lecture lecture = Lecture.of(request.getName(), authInfo.getMemberId(), request.getClassSize());
+    Lecture lecture = Lecture.of(request.getName(), authInfo.getInstructorId(),
+        request.getClassSize());
     lectureMapper.insertLecture(lecture);
   }
 
-  public List<LectureResponseDto> getLectureListByInstructorID(AuthInfo authInfo) {
-    List<Lecture> lectures = lectureMapper.findByInstructorId(authInfo.getMemberId());
+  public List<LectureResponseDto> getLectureListByInstructorId(AuthInfo authInfo) {
+    if (!authInfo.isInstructor()) {
+      throw new RuntimeException("교수자 권한이 필요");
+    }
+
+    Long instructorId = authInfo.getInstructorId();
+    if (instructorId == null) {
+      throw new RuntimeException("교수자 ID를 찾지 못함");
+    }
+
+    List<Lecture> lectures = lectureMapper.findByInstructorId(instructorId);
+
+    if (lectures.isEmpty()) {
+      return Collections.emptyList();
+    }
+
     return LectureResponseDto.from(lectures);
   }
 
   public List<LectureResponseDto> getLectureListByStudentId(AuthInfo authInfo) {
-    Long studentId = authInfo.getMemberId();
+    if (!authInfo.isStudent()) {
+      throw new RuntimeException("학생 권한이 필요");
+    }
+
+    Long studentId = authInfo.getStudentId();
 
     List<Long> lectureIds = lectureMapper.findLectureIdsByStudentId(studentId);
 
@@ -61,7 +80,7 @@ public class LectureService {
       throw new RuntimeException();
     }
     if (authInfo.isInstructor()
-        && lecture.isOwnedBy(authInfo.getMemberId())) {
+        && lecture.isOwnedBy(authInfo.getInstructorId())) {
       throw new RuntimeException();
     }// TODO: 학생 -> 수강신청한 강의인지 확인하는 로직 추가 필요
 
@@ -70,21 +89,24 @@ public class LectureService {
 
   @Transactional
   public LectureJoinResponse joinLecture(String code, AuthInfo authInfo) {
+    if (!authInfo.isStudent()) {
+      throw new RuntimeException("학생만 강의에 참여 가능");
+    }
 
-    Student student = memberMapper.findStudentById(authInfo.getMemberId());
+    Student student = memberMapper.findStudentById(authInfo.getStudentId());
 
     if (student == null) {
-      throw new RuntimeException();
+      throw new RuntimeException("학생 정보를 찾을 수 없음");
     }
 
     Lecture lecture = lectureMapper.findLectureByCode(code);
 
     if (lecture == null) {
-      throw new RuntimeException();
+      throw new RuntimeException("강의를 찾을 수 없음");
     }
 
     if (lectureMapper.existEnrollmentByStudentIdAndLectureID(student.getId(), lecture.getId())) {
-      throw new RuntimeException();
+      throw new RuntimeException("이미 수강신청한 강의");
     }
 
     lectureMapper.insertLectureStudent(student.getId(), lecture.getId());

--- a/src/main/resources/mapper/AuthMapper.xml
+++ b/src/main/resources/mapper/AuthMapper.xml
@@ -1,37 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.gatheria.mapper.AuthMapper">
 
-    <resultMap id="StudentResultMap" type="com.gatheria.domain.Student">
-        <id property="id" column="student_id"/>
-        <result property="email" column="email"/>
-        <result property="password" column="password"/>
-        <result property="name" column="name"/>
-        <result property="phone" column="phone"/>
-        <result property="active" column="active"/>
-    </resultMap>
+  <resultMap id="StudentResultMap" type="com.gatheria.domain.Student">
+    <id property="id" column="student_id"/>
+    <result property="email" column="email"/>
+    <result property="password" column="password"/>
+    <result property="name" column="name"/>
+    <result property="phone" column="phone"/>
+    <result property="active" column="active"/>
+  </resultMap>
 
-    <resultMap id="InstructorResultMap" type="com.gatheria.domain.Instructor">
-        <id property="id" column="instructor_id"/>
-        <result property="email" column="email"/>
-        <result property="password" column="password"/>
-        <result property="name" column="name"/>
-        <result property="phone" column="phone"/>
-        <result property="active" column="active"/>
-        <result property="affiliation" column="affiliation"/>
-    </resultMap>
+  <resultMap id="InstructorResultMap" type="com.gatheria.domain.Instructor">
+    <id property="id" column="instructor_id"/>
+    <result property="email" column="email"/>
+    <result property="password" column="password"/>
+    <result property="name" column="name"/>
+    <result property="phone" column="phone"/>
+    <result property="active" column="active"/>
+    <result property="affiliation" column="affiliation"/>
+  </resultMap>
 
-    <select id="findStudentByEmail" parameterType="string" resultMap="StudentResultMap">
-        SELECT members.*, students.id as student_id
-        FROM members
-                 JOIN students ON members.id = students.member_id
-        WHERE members.email = #{email}
-    </select>
+  <select id="findStudentByEmail" parameterType="string" resultMap="StudentResultMap">
+    SELECT members.*, students.id as student_id
+    FROM members
+           JOIN students ON members.id = students.member_id
+    WHERE members.email = #{email}
+  </select>
 
-    <select id="findInstructorByEmail" parameterType="string" resultMap="InstructorResultMap">
-        SELECT members.*, instructors.id as instructor_id, instructors.affiliation
-        FROM members
-                 JOIN instructors ON members.id = instructors.member_id
-        WHERE members.email = #{email}
-    </select>
+  <select id="findInstructorByEmail" parameterType="string" resultMap="InstructorResultMap">
+    SELECT members.*, instructors.id as instructor_id, instructors.affiliation
+    FROM members
+           JOIN instructors ON members.id = instructors.member_id
+    WHERE members.email = #{email}
+  </select>
+
+  <select id="findStudentIdByMemberId" resultType="Long">
+    SELECT id
+    FROM students
+    WHERE member_id = #{memberId}
+  </select>
+
+  <select id="findInstructorIdByMemberId" resultType="Long">
+    SELECT id
+    FROM instructors
+    WHERE member_id = #{memberId}
+  </select>
 </mapper>


### PR DESCRIPTION
### 구현 내용

- AuthInfo 클래스에 studentId 및 instructorId 필드 추가
- JWT 토큰에 역할별 ID(studentId/instructorId) 정보 포함
- JwtUtil에 역할별 토큰 생성 및 ID 추출 메서드 구현
- 강의 관련 서비스에서 memberId 대신 역할별 ID 사용하도록 변경
- 매개변수 이름을 실제 역할에 맞게 수정하여 일관성 확보

---

### 메인 리뷰어 지정 및 Due Date
@blue000927 

---

### 관련 이슈 
#27 

---

### 체크리스트
- [x]  PR 제목을 명령형으로 작성했습니다.
- [x]  PR을 연관되는 github issue에 연결했습니다.
- [x]  리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다.