### PR TITLE
멘토링 등록 시 발생하는 데드락 이슈 해결

### DIFF
--- a/script/concurrency-tests/run-test.sh
+++ b/script/concurrency-tests/run-test.sh
@@ -1,38 +1,17 @@
 #!/bin/bash
-SCRIPT_NAME=${1:-register.js}
 
-# 비밀 환경 변수 로딩
-source ./secrets.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+K6_SCRIPT="$PARENT_DIR/registerPattern2.js"
 
-SUMMARY_PATH="./script/summary.json"
+echo "🔄 K6 Register Script 실행: $K6_SCRIPT"
+echo
 
-
-echo "🚀 K6 테스트 시작: $SCRIPT_NAME"
-SCRIPT=$SCRIPT_NAME docker compose -f docker-compose.k6.yml up --abort-on-container-exit
-RESULT=$?
-
-# summary 파일이 없으면 실패 처리
-if [ ! -f "$SUMMARY_PATH" ]; then
-  MSG="❌ *K6 테스트 실패!* summary.json이 생성되지 않았습니다.\n스크립트: \`$SCRIPT_NAME\`"
-else
-  # JSON 파싱 (경로 수정!)
-  REQS=$(jq '.metrics.http_reqs.count' $SUMMARY_PATH)
-  FAILED=$(jq '.metrics.http_req_failed.value' $SUMMARY_PATH)
-  DURATION=$(jq '.metrics.http_req_duration.avg' $SUMMARY_PATH)
-  P95=$(jq '.metrics.http_req_duration["p(95)"]' $SUMMARY_PATH)
-
-  # 메시지 구성
-  if [ "$FAILED" == "0" ]; then
-    ICON="✅"
-  else
-    ICON="⚠️"
-  fi
-
-  MSG="$ICON *K6 테스트 완료*\n📄 \`$SCRIPT_NAME\`\n📊 총 요청: *$REQS*\n❌ 실패율: *$(awk "BEGIN {printf \"%.2f\", $FAILED * 100}")%*\n⏱️ 평균 응답: *$(awk "BEGIN {printf \"%.2f\", $DURATION}")s*, P95: *$(awk "BEGIN {printf \"%.2f\", $P95}")s*"
+if [ ! -f "$K6_SCRIPT" ]; then
+  echo "❌ registerPattern2.js 스크립트를 찾을 수 없습니다."
+  exit 1
 fi
 
-# 슬랙 전송
-curl -X POST -H 'Content-type: application/json' \
---data "{\"text\":\"$MSG\"}" "$SLACK_WEBHOOK_URL"
-
-echo "📬 슬랙 메시지 전송 완료!"
+docker run --rm -i \
+  -v "$PARENT_DIR:/scripts" \
+  grafana/k6 run /scripts/registerPattern2.js

--- a/script/deadlock-test2.js
+++ b/script/deadlock-test2.js
@@ -1,0 +1,138 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+
+function randomIntBetween(min, max) {
+  return Math.floor(Math.random() * (max - min + 1) + min);
+}
+
+export let options = {
+  scenarios: {
+    deadlock_scenario: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 100,
+      stages: [
+        {target: 10, duration: '5s'},
+        {target: 55, duration: '5s'},
+        {target: 100, duration: '5s'},
+        {target: 100, duration: '10s'},
+        {target: 0, duration: '5s'}
+      ],
+    }
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.3'],
+    http_req_duration: ['p(95)<3000'],
+  },
+};
+
+const SESSION_ID = 2;
+
+export default function () {
+  const id = __VU; // VU 1~100 → student1~student100 1:1 매핑
+
+  const student = {
+    email: `student${id}@gatheria.com`,
+    password: 'Password123!',
+  };
+
+  // 로그인
+  const loginRes = http.post(
+      'http://host.docker.internal:8080/api/auth/student/login',
+      JSON.stringify(student),
+      {headers: {'Content-Type': 'application/json'}}
+  );
+
+  check(loginRes, {
+    '로그인 성공': (res) => res.status === 200,
+  });
+
+  if (loginRes.status !== 200) {
+    console.error(
+        `로그인 실패: 학생${id}, 상태 ${loginRes.status}, 응답: ${loginRes.body}`);
+    return;
+  }
+
+  const token = loginRes.json('accessToken');
+
+  // 그룹별 요청 타이밍 조정
+  if (id <= 20) {
+    sleep(randomIntBetween(0, 200) / 1000);
+  } else if (id <= 50) {
+    const targetTime = new Date().getTime() + 100;
+    const now = new Date().getTime();
+    if (targetTime > now) {
+      sleep((targetTime - now) / 1000);
+    }
+  } else {
+    sleep(randomIntBetween(300, 500) / 1000);
+  }
+
+  // 세션 등록 요청
+  const startTime = new Date().getTime();
+  const joinRes = http.post(
+      `http://host.docker.internal:8080/api/mentoring/${SESSION_ID}/join`,
+      null,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        tags: {name: '멘토링_세션_등록'},
+      }
+  );
+  const responseTime = new Date().getTime() - startTime;
+
+  const hasDeadlock =
+      joinRes.body.includes('Deadlock') ||
+      joinRes.body.includes('transaction') ||
+      (joinRes.status === 500 && joinRes.body.includes('try restarting'));
+
+  if (hasDeadlock) {
+    console.error(
+        `[⚠️ 데드락 감지] 학생${id}, 응답시간: ${responseTime}ms, 응답: ${joinRes.body.substring(
+            0, 200)}`
+    );
+  } else if (joinRes.status === 500) {
+    console.error(
+        `[❌ 서버 오류] 학생${id}, 응답시간: ${responseTime}ms, 응답: ${joinRes.body.substring(
+            0, 100)}`
+    );
+  } else if (joinRes.status === 200) {
+    console.log(`[✅ 등록 성공] 학생${id}, 응답시간: ${responseTime}ms`);
+  } else if (joinRes.status === 409) {
+    console.log(
+        `[⚙️ 등록 불가] 학생${id}, 응답시간: ${responseTime}ms, 사유: ${joinRes.body.substring(
+            0, 50)}`
+    );
+  } else {
+    console.log(
+        `[❓ 기타 응답] 학생${id}, 상태: ${joinRes.status}, 응답시간: ${responseTime}ms`
+    );
+  }
+
+  check(joinRes, {
+    '세션 등록 처리됨': (res) => res.status === 200 || res.status === 409,
+    '데드락 없음': (res) => !hasDeadlock,
+  });
+
+  // 성공한 경우 상태 확인
+  if (joinRes.status === 200) {
+    sleep(randomIntBetween(100, 300) / 1000);
+
+    const checkRes = http.get(
+        `http://host.docker.internal:8080/api/mentoring/sessions/${SESSION_ID}/status`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+    );
+
+    check(checkRes, {
+      '등록 상태 확인 성공': (res) => res.status === 200,
+    });
+  }
+}

--- a/script/registerPattern2.js
+++ b/script/registerPattern2.js
@@ -1,0 +1,36 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+
+export let options = {
+  vus: 1,               // 락 줄이기 위해 순차 실행
+  iterations: 537,     // student464 ~ student1000
+};
+
+export default function () {
+  const id = __ITER + 1;       // 1 ~ 537
+  const num = id + 463;        // 464 ~ 1000
+
+  const user = {
+    email: `student${num}@gatheria.com`,
+    password: 'Password123!',
+    name: `Student ${num}`,
+    phone: `0101234${String(num).padStart(4, '0')}`,
+  };
+
+  const url = 'http://host.docker.internal:8080/api/member/student/register';
+
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  };
+
+  const res = http.post(url, JSON.stringify(user), params);
+
+  check(res, {
+    [`학생 ${num} 상태 200`]: (r) => r.status === 200,
+    '응답 코드 < 400': (r) => r.status < 400,
+  });
+
+  sleep(0.5); // 부하 줄이기 위해 느리게 진행
+}

--- a/src/main/java/com/gatheria/mapper/MentoringSessionMapper.java
+++ b/src/main/java/com/gatheria/mapper/MentoringSessionMapper.java
@@ -36,9 +36,13 @@ public interface MentoringSessionMapper {
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void insertParticipant(SessionParticipant participant);
 
-
   @Select("SELECT * FROM mentoring_sessions WHERE id = #{sessionId}")
   MentoringSession getSession(Long sessionId);
+
+  // get session + 배타적 락
+  @Select("SELECT * FROM mentoring_sessions WHERE id = #{sessionId} FOR UPDATE")
+  MentoringSession getSessionForUpdate(Long sessionId);
+
 
   @Select("SELECT * FROM mentoring_sessions")
   List<MentoringSession> findAllSessions();

--- a/src/main/java/com/gatheria/service/MentoringSessionService.java
+++ b/src/main/java/com/gatheria/service/MentoringSessionService.java
@@ -49,37 +49,22 @@ public class MentoringSessionService {
   @Transactional
   public MentoringSessionRegistrationResponseDto registerSession(Long sessionId,
       AuthInfo authInfo, LocalDateTime requestAt) {
-    log.info("세션 등록 시작: sessionId={}, studentId={}", sessionId, authInfo.getStudentId());
-
     authInfo.validateStudent();
-    log.debug("학생 검증 완료");
 
-    log.info("세션 배타적 락 획득 시도: sessionId={}", sessionId);
-    //MentoringSession session = mentoringSessionMapper.getSession(sessionId);
     MentoringSession session = mentoringSessionMapper.getSessionForUpdate(sessionId);
-    log.info("세션 락 획득 완료: sessionId={}, 현재참여자={}", sessionId, session.getCurrentParticipants());
 
-    // 존재하지 않는 멘토링
     if (session == null) {
-      log.warn("존재하지 않는 세션: sessionId={}", sessionId);
       return MentoringSessionRegistrationResponseDto.fail("해당 세션이 존재x.", HttpStatus.NOT_FOUND);
     }
 
-    // 이미 등록된 멘토링인지 확인
     SessionParticipant existing = mentoringSessionMapper.findLatestBySessionAndStudent(sessionId,
         authInfo.getStudentId());
-    log.debug("기존 참여 조회 완료: sessionId={}, 기존참여={}", sessionId, existing != null);
 
-    // 이미 기록 존재 & 등록된 상태
     if (existing != null && SessionParticipantStatus.REGISTERED == existing.getStatus()) {
-      log.warn("이미 등록된 세션: sessionId={}, studentId={}", sessionId, authInfo.getStudentId());
       return MentoringSessionRegistrationResponseDto.fail("이미 등록된 세션입니다.", HttpStatus.CONFLICT);
     }
 
-    // 현재 정원 초과인 상태인지 체크
     if (session.getCurrentParticipants() >= session.getMaxParticipants()) {
-      log.warn("정원 초과: sessionId={}, 현재={}, 최대={}",
-          sessionId, session.getCurrentParticipants(), session.getMaxParticipants());
 
       SessionParticipant participant = SessionParticipant.of(sessionId, authInfo.getStudentId(),
           requestAt);
@@ -94,7 +79,6 @@ public class MentoringSessionService {
     }
 
     if (session.getStatus() != MentoringStatus.WAITING_OPEN) {
-      log.warn("등록 불가 상태: sessionId={}, 현재상태={}", sessionId, session.getStatus());
       return MentoringSessionRegistrationResponseDto.fail(
           "현재 등록 불가 , 세션 상태: " + session.getStatus(),
           HttpStatus.BAD_REQUEST
@@ -104,25 +88,12 @@ public class MentoringSessionService {
     SessionParticipant participant = SessionParticipant.of(sessionId, authInfo.getStudentId(),
         requestAt);
     participant.completeRegistration();
-    //===Deadlock 발생 가능성이 있음===
-//    mentoringSessionMapper.insertParticipant(participant);
-//    session.incrementCurrentParticipants(); //
-//    mentoringSessionMapper.updateSession(session);
 
-    // 순서 변경 (update -> insert)
-    log.info("세션 업데이트 시작: sessionId={}, 현재참여자={}", sessionId, session.getCurrentParticipants());
     session.incrementCurrentParticipants();
     mentoringSessionMapper.updateSession(session);
-    log.info("세션 업데이트 완료: sessionId={}, 업데이트된참여자={}", sessionId, session.getCurrentParticipants());
 
-    log.info("참여자 등록 시작: sessionId={}, studentId={}", sessionId, authInfo.getStudentId());
     mentoringSessionMapper.insertParticipant(participant);
-    log.info("참여자 등록 완료: sessionId={}, participantId={}", sessionId, participant.getId());
 
-    log.info("세션 등록 완료: sessionId={}", sessionId);
-    //===Deadlock 발생 가능성이 있음===
-
-    log.info("트랜잭션 완료 직전: sessionId={}", sessionId);
     return MentoringSessionRegistrationResponseDto.success(
         session.getId(),
         session.getTitle(),

--- a/src/main/java/com/gatheria/service/MentoringSessionService.java
+++ b/src/main/java/com/gatheria/service/MentoringSessionService.java
@@ -12,12 +12,14 @@ import com.gatheria.dto.response.MentoringSessionResponseDto;
 import com.gatheria.mapper.MentoringSessionMapper;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 public class MentoringSessionService {
 
   private final MentoringSessionMapper mentoringSessionMapper;
@@ -47,25 +49,38 @@ public class MentoringSessionService {
   @Transactional
   public MentoringSessionRegistrationResponseDto registerSession(Long sessionId,
       AuthInfo authInfo, LocalDateTime requestAt) {
+    log.info("세션 등록 시작: sessionId={}, studentId={}", sessionId, authInfo.getStudentId());
+
     authInfo.validateStudent();
-    MentoringSession session = mentoringSessionMapper.getSession(sessionId);
+    log.debug("학생 검증 완료");
+
+    log.info("세션 배타적 락 획득 시도: sessionId={}", sessionId);
+    //MentoringSession session = mentoringSessionMapper.getSession(sessionId);
+    MentoringSession session = mentoringSessionMapper.getSessionForUpdate(sessionId);
+    log.info("세션 락 획득 완료: sessionId={}, 현재참여자={}", sessionId, session.getCurrentParticipants());
 
     // 존재하지 않는 멘토링
     if (session == null) {
+      log.warn("존재하지 않는 세션: sessionId={}", sessionId);
       return MentoringSessionRegistrationResponseDto.fail("해당 세션이 존재x.", HttpStatus.NOT_FOUND);
     }
 
     // 이미 등록된 멘토링인지 확인
     SessionParticipant existing = mentoringSessionMapper.findLatestBySessionAndStudent(sessionId,
         authInfo.getStudentId());
+    log.debug("기존 참여 조회 완료: sessionId={}, 기존참여={}", sessionId, existing != null);
 
     // 이미 기록 존재 & 등록된 상태
     if (existing != null && SessionParticipantStatus.REGISTERED == existing.getStatus()) {
+      log.warn("이미 등록된 세션: sessionId={}, studentId={}", sessionId, authInfo.getStudentId());
       return MentoringSessionRegistrationResponseDto.fail("이미 등록된 세션입니다.", HttpStatus.CONFLICT);
     }
 
     // 현재 정원 초과인 상태인지 체크
     if (session.getCurrentParticipants() >= session.getMaxParticipants()) {
+      log.warn("정원 초과: sessionId={}, 현재={}, 최대={}",
+          sessionId, session.getCurrentParticipants(), session.getMaxParticipants());
+
       SessionParticipant participant = SessionParticipant.of(sessionId, authInfo.getStudentId(),
           requestAt);
       participant.reject();
@@ -79,6 +94,7 @@ public class MentoringSessionService {
     }
 
     if (session.getStatus() != MentoringStatus.WAITING_OPEN) {
+      log.warn("등록 불가 상태: sessionId={}, 현재상태={}", sessionId, session.getStatus());
       return MentoringSessionRegistrationResponseDto.fail(
           "현재 등록 불가 , 세션 상태: " + session.getStatus(),
           HttpStatus.BAD_REQUEST
@@ -88,11 +104,25 @@ public class MentoringSessionService {
     SessionParticipant participant = SessionParticipant.of(sessionId, authInfo.getStudentId(),
         requestAt);
     participant.completeRegistration();
-    mentoringSessionMapper.insertParticipant(participant); // 참여자 정보 저장(로그 참여자리스트)
+    //===Deadlock 발생 가능성이 있음===
+//    mentoringSessionMapper.insertParticipant(participant);
+//    session.incrementCurrentParticipants(); //
+//    mentoringSessionMapper.updateSession(session);
 
-    session.incrementCurrentParticipants(); // 현재 참여자 수 증가
-    mentoringSessionMapper.updateSession(session); // 멘토링 세션 테이블 저장(상태랑 숫자)
+    // 순서 변경 (update -> insert)
+    log.info("세션 업데이트 시작: sessionId={}, 현재참여자={}", sessionId, session.getCurrentParticipants());
+    session.incrementCurrentParticipants();
+    mentoringSessionMapper.updateSession(session);
+    log.info("세션 업데이트 완료: sessionId={}, 업데이트된참여자={}", sessionId, session.getCurrentParticipants());
 
+    log.info("참여자 등록 시작: sessionId={}, studentId={}", sessionId, authInfo.getStudentId());
+    mentoringSessionMapper.insertParticipant(participant);
+    log.info("참여자 등록 완료: sessionId={}, participantId={}", sessionId, participant.getId());
+
+    log.info("세션 등록 완료: sessionId={}", sessionId);
+    //===Deadlock 발생 가능성이 있음===
+
+    log.info("트랜잭션 완료 직전: sessionId={}", sessionId);
     return MentoringSessionRegistrationResponseDto.success(
         session.getId(),
         session.getTitle(),

--- a/src/main/java/com/gatheria/service/MentoringSessionService.java
+++ b/src/main/java/com/gatheria/service/MentoringSessionService.java
@@ -47,10 +47,7 @@ public class MentoringSessionService {
   @Transactional
   public MentoringSessionRegistrationResponseDto registerSession(Long sessionId,
       AuthInfo authInfo, LocalDateTime requestAt) {
-    if (!authInfo.isStudent()) {
-      throw new RuntimeException("학생만 가능함");
-    }
-
+    authInfo.validateStudent();
     MentoringSession session = mentoringSessionMapper.getSession(sessionId);
 
     // 존재하지 않는 멘토링

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -75,21 +75,6 @@
                 WHERE id = #{id})
   </update>
 
-
-  <select id="findStudentInfoMapByIds" resultType="com.gatheria.dto.StudentInfoResponseDto">
-    SELECT
-    s.id AS studentId,
-    m.name,
-    m.email
-    FROM students s
-    JOIN members m ON s.member_id = m.id
-    WHERE s.id IN
-    <foreach collection="studentIds" item="id" open="(" separator="," close=")">
-      #{id}
-    </foreach>
-  </select>
-
-
   <select id="findStudentInfoMapByIds"
     resultType="com.gatheria.dto.response.StudentInfoResponseDto">
     SELECT
@@ -103,6 +88,5 @@
       #{id}
     </foreach>
   </select>
-
-
+  
 </mapper>


### PR DESCRIPTION
### 문제
- 여러 사용자가 동시에 동일한 멘토링 세션에 등록 시도할 때 데드락 발생
- InnoDB 모니터 로그에서 mentoring_sessions 테이블 업데이트 시 교착 상태 확인
- 동일 레코드에 대한 S락과 X락 획득 과정에서 데드락 발생
- 데드락에 영향을 받아 race condition 문제 발생



### 해결
**배타적 락(FOR UPDATE) 적용**
- 트랜잭션 시작 시 세션 조회할 때 FOR UPDATE 구문 추가
- 동시 접근 시 한 트랜잭션만 락 획득, 나머지는 대기하도록 변경
**테이블 접근 순서 변경**
- (기존) insertParticipant -> updateSession
- (변경) updateSession → insertParticipant

<img width="918" alt="Pasted image 20250331190811" src="https://github.com/user-attachments/assets/e30a6f24-601b-472e-930a-40672c929a92" />

---

**변경 전 테스트 결과**

```
===== 테스트 후 데드락 수 측정 =====
측정 시각: 2025-03-30 22:16:26
현재 데드락 수: 262
이번 테스트에서 발생한 데드락 수: 20 건
테스트 시간: 39 초
초당 요청 수 (RPS): 13.77
평균 응답시간: 5035.996226692734ms
P95 응답시간: 15608.943104199998ms

---

===== 테스트 후 데드락 수 측정 =====
측정 시각: 2025-03-30 22:18:45
현재 데드락 수: 284
이번 테스트에서 발생한 데드락 수: 22 건
테스트 시간: 54 초
초당 요청 수 (RPS): 9.54
평균 응답시간: 5484.605727056305ms
P95 응답시간: 17689.447802699997ms


docker exec -it gatheria-mysql-1 mysql -uroot -p1234 -D gatheria -e "
SELECT COUNT(*) AS registered_count
FROM session_participants
WHERE session_id = 2
  AND status = 'REGISTERED';"


+------------------+
| registered_count |
+------------------+
|               59 | -> 정원 50명인 상황
+------------------+

race condition 발생
<img width="687" alt="스크린샷 2025-03-30 오후 10 24 58" src="https://github.com/user-attachments/assets/1b1307d6-228b-4586-b18a-d258c4688798" />



---

===== 테스트 후 데드락 수 측정 =====
측정 시각: 2025-03-30 22:26:56
현재 데드락 수: 309
이번 테스트에서 발생한 데드락 수: 25 건
테스트 시간: 41 초
초당 요청 수 (RPS): 12.98
평균 응답시간: 5458.310200208649ms
P95 응답시간: 16760.163422499998ms


 docker exec -it gatheria-mysql-1 mysql -uroot -p1234 -D gatheria -e "
SELECT COUNT(*) AS registered_count
FROM session_participants
WHERE session_id = 2
  AND status = 'REGISTERED';"
mysql: [Warning] Using a password on the command line interface can be insecure.
+------------------+
| registered_count |
+------------------+
|               58 |
+------------------+

---


===== 테스트 후 데드락 수 측정 =====
측정 시각: 2025-03-30 23:21:32
현재 데드락 수: 325
이번 테스트에서 발생한 데드락 수: 16 건
테스트 시간: 39 초
초당 요청 수 (RPS): 14.10
평균 응답시간: 5074.901361799997ms
P95 응답시간: 13802.55609025ms

 docker exec -it gatheria-mysql-1 mysql -uroot -p1234 -D gatheria -e "
SELECT COUNT(*) AS registered_count
FROM session_participants
WHERE session_id = 2
  AND status = 'REGISTERED';"
mysql: [Warning] Using a password on the command line interface can be insecure.
+------------------+
| registered_count |
+------------------+
|               56 |
+------------------+
```

**변경 후 테스트 결과**
```
===== 테스트 후 데드락 수 측정 =====
측정 시각: 2025-03-31 19:40:36
현재 데드락 수: 268
이번 테스트에서 발생한 데드락 수: 0 건
테스트 시간: 41 초
초당 요청 수 (RPS): 8.73
평균 응답시간: 8125.784061332401ms
P95 응답시간: 17110.8451296ms


===== 테스트 후 데드락 수 측정 =====
측정 시각: 2025-03-31 19:44:19
현재 데드락 수: 268
이번 테스트에서 발생한 데드락 수: 0 건
테스트 시간: 39 초
초당 요청 수 (RPS): 8.67
평균 응답시간: 8831.90145076036ms
P95 응답시간: 23150.740256899997ms
```

---

### 메인 리뷰어 지정 및 Due Date
@blue000927 

### 관련 이슈
#30 

### 체크리스트
- [x]  PR 제목을 명령형으로 작성했습니다.
- [x]  PR을 연관되는 github issue에 연결했습니다.
- [x]  리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다.
